### PR TITLE
delay population of DeviceSettingsView::DeviceSettingsView until really needed

### DIFF
--- a/src/application.cc
+++ b/src/application.cc
@@ -46,7 +46,7 @@ Application::Application(int &argc, char *argv[])
 
   switch (settings.tutor()) {
   case Settings::TUTOR_KOCH:
-    _tutor = new KochTutor(_encoder, settings.kochLesson(), settings.kochPrefLastChars(), settings.kochRepeatLastChar(),
+    _tutor = new KochTutor(_encoder, settings.kochLesson(), settings.kochPrefLastChars(), settings.KochLastCharFrequencyFactor(), settings.kochRepeatLastChar(),
                            settings.kochMinGroupSize(), settings.kochMaxGroupSize(),
                            (settings.kochInfiniteLineCount() ? -1: settings.kochLineCount()),
                            settings.kochSummary(), settings.kochSuccessThreshold(), this);
@@ -170,7 +170,7 @@ Application::applySettings()
 
   switch (settings.tutor()) {
     case Settings::TUTOR_KOCH:
-      _tutor = new KochTutor(_encoder, settings.kochLesson(), settings.kochPrefLastChars(),
+      _tutor = new KochTutor(_encoder, settings.kochLesson(), settings.kochPrefLastChars(), settings.KochLastCharFrequencyFactor(),
                              settings.kochRepeatLastChar(), settings.kochMinGroupSize(), settings.kochMaxGroupSize(),
                              (settings.kochInfiniteLineCount() ? -1: settings.kochLineCount()),
                              settings.kochSummary(), settings.kochSuccessThreshold(), this);

--- a/src/mainwindow.cc
+++ b/src/mainwindow.cc
@@ -26,8 +26,8 @@ MainWindow::MainWindow(Application &app, QWidget *parent)
   _text = new QTextEdit();
   _text->setMinimumSize(640,230);
   QFont f = _text->document()->defaultFont();
-  f.setFamily("Courier");
-  f.setPointSize(14);
+  f.setFamily("Monospace");
+  f.setPointSize(11);
   f.setStyleHint(QFont::Monospace);
   _text->document()->setDefaultFont(f);
   _text->setReadOnly(true);

--- a/src/settings.cc
+++ b/src/settings.cc
@@ -1226,33 +1226,17 @@ EffectSettingsView::onQRMToggled(bool enabled) {
 DeviceSettingsView::DeviceSettingsView(QWidget *parent)
   : QWidget(parent)
 {
-    //Settings settings;
     _settings = new Settings();
 
   _outputDevices = new QComboBox();
   _outputDevices->setToolTip(tr("Select the audio output device."));
-//  QAudioDeviceInfo currentDevice = settings.outputDevice();
-//  QList<QAudioDeviceInfo> devices = QAudioDeviceInfo::availableDevices(QAudio::AudioOutput);
-//  foreach (auto device, devices) {
-//    _outputDevices->addItem(device.deviceName());
-//    if (device == currentDevice)
-//      _outputDevices->setCurrentIndex(_outputDevices->model()->rowCount()-1);
-//  }
 
   _inputDevices = new QComboBox();
   _inputDevices->setToolTip(tr("Select the audio input device used for decoding CW send by you."));
-//  currentDevice = settings.inputDevice();
-//  devices = QAudioDeviceInfo::availableDevices(QAudio::AudioInput);
-//  foreach (auto device, devices) {
-//    _inputDevices->addItem(device.deviceName());
-//    if (device == currentDevice)
-//      _inputDevices->setCurrentIndex(_inputDevices->model()->rowCount()-1);
-//  }
 
   _decoderLevel = new QSpinBox();
   _decoderLevel->setMinimum(-60);
   _decoderLevel->setMaximum(0);
-//  _decoderLevel->setValue(int(settings.decoderLevel()));
   _decoderLevel->setValue(int(_settings->decoderLevel()));
 
   _decoderLevel->setToolTip(tr("Specifies the detector threshold in dB for decoding CW."));

--- a/src/settings.cc
+++ b/src/settings.cc
@@ -459,7 +459,13 @@ SettingsDialog::SettingsDialog(QWidget *parent)
   _tabs->addTab(_effects, tr("Effects"));
   _tabs->addTab(_devices, tr("Devices"));
 
-  QObject::connect(_tabs, SIGNAL(currentChanged(int)), this, SLOT(tabSelected()));
+  // populating device settings may takes a lot of time so only do if the tab becomes visible
+  QObject::connect(_tabs, &QTabWidget::currentChanged, [this](){
+    if(_tabs->currentIndex()==3) {
+        _devices->populateDeviceSettingsView();
+    }
+  });
+
 
   QDialogButtonBox *bbox = new QDialogButtonBox();
   bbox->addButton(QDialogButtonBox::Ok);
@@ -474,13 +480,6 @@ SettingsDialog::SettingsDialog(QWidget *parent)
   QObject::connect(bbox, SIGNAL(accepted()), this, SLOT(accept()));
   QObject::connect(bbox, SIGNAL(rejected()), this, SLOT(reject()));
   QObject::connect(bbox, SIGNAL(helpRequested()), this, SLOT(showHelp()));
-}
-
-void
-SettingsDialog::tabSelected() {
-    if(_tabs->currentIndex()==3) {
-        _devices->populateDeviceSettingsView();
-    }
 }
 
 void

--- a/src/settings.cc
+++ b/src/settings.cc
@@ -182,6 +182,14 @@ Settings::setKochPrefLastChars(bool pref) {
   this->setValue("koch/prefLastChars", pref);
 }
 
+void Settings::setKochLastCharFrequencyFactor(int lastCharFrequencyFactor) {
+  this->setValue("koch/lastCharFrequencyFactor", lastCharFrequencyFactor);
+}
+
+int Settings::KochLastCharFrequencyFactor() const {
+  return this->value("koch/lastCharFrequencyFactor", 1).toInt();
+}
+
 bool
 Settings::kochRepeatLastChar() const {
   return this->value("koch/repeatLastChar", false).toBool();
@@ -672,6 +680,11 @@ KochTutorSettingsView::KochTutorSettingsView(QWidget *parent)
   _prefLastChars->setChecked(settings.kochPrefLastChars());
   _prefLastChars->setToolTip(tr("If enabled, increases the likelihood of newer symbols."));
 
+  _lastCharFrequencyFactor = new QSpinBox();
+  _lastCharFrequencyFactor->setMinimum(1); _lastCharFrequencyFactor->setMaximum(4);
+  _lastCharFrequencyFactor->setValue(settings.KochLastCharFrequencyFactor());
+  _lastCharFrequencyFactor->setToolTip(tr("Influence the increase in the likelihood of newer symbols."));
+
   _repLastChar = new QCheckBox();
   _repLastChar->setChecked(settings.kochRepeatLastChar());
   _repLastChar->setToolTip(tr("If enabled, repeats the new symbol before the lesson starts."));
@@ -718,10 +731,12 @@ KochTutorSettingsView::KochTutorSettingsView(QWidget *parent)
   connect(_maxGroupSize, SIGNAL(valueChanged(int)), this, SLOT(onMaxSet(int)));
   connect(_infinite, SIGNAL(toggled(bool)), this, SLOT(onInfiniteToggled(bool)));
   connect(_summary, SIGNAL(toggled(bool)), this, SLOT(onShowSummaryToggled(bool)));
+  connect(_prefLastChars, SIGNAL(toggled(bool)), this, SLOT(onPreferLastCharToggled(bool)));
 
   QFormLayout *layout = new QFormLayout();
   layout->addRow(tr("Lesson"), _lesson);
   layout->addRow(tr("Prefer last chars"), _prefLastChars);
+  layout->addRow(tr("Set last char frequency factor"), _lastCharFrequencyFactor);
   layout->addRow(tr("Repeat last char"), _repLastChar);
   layout->addRow(tr("Min. group size"), _minGroupSize);
   layout->addRow(tr("Max. group size"), _maxGroupSize);
@@ -738,6 +753,7 @@ KochTutorSettingsView::save() {
   Settings settings;
   settings.setKochLesson(_lesson->value());
   settings.setKochPrefLastChars(_prefLastChars->isChecked());
+  settings.setKochLastCharFrequencyFactor(_lastCharFrequencyFactor->value());
   settings.setKochRepeatLastChar(_repLastChar->isChecked());
   settings.setKochMinGroupSize(_minGroupSize->value());
   settings.setKochMaxGroupSize(_maxGroupSize->value());
@@ -769,6 +785,10 @@ KochTutorSettingsView::onShowSummaryToggled(bool enabled) {
   _threshold->setEnabled(enabled);
 }
 
+void
+KochTutorSettingsView::onPreferLastCharToggled(bool enabled) {
+  _lastCharFrequencyFactor->setEnabled(enabled);
+}
 
 /* ********************************************************************************************* *
  * Random Tutor Settings Widget

--- a/src/settings.cc
+++ b/src/settings.cc
@@ -451,6 +451,8 @@ SettingsDialog::SettingsDialog(QWidget *parent)
   _tutor = new TutorSettingsView();
   _code  = new CodeSettingsView();
   _effects = new EffectSettingsView();
+
+  /* TODO: split DeviceSettingsView into a dummy and delay the population of it */
   _devices = new DeviceSettingsView();
 
   _tabs = new QTabWidget();
@@ -458,6 +460,8 @@ SettingsDialog::SettingsDialog(QWidget *parent)
   _tabs->addTab(_code, tr("Morse Code"));
   _tabs->addTab(_effects, tr("Effects"));
   _tabs->addTab(_devices, tr("Devices"));
+
+  QObject::connect(_tabs, SIGNAL(currentChanged(int)), this, SLOT(tabSelected()));
 
   QDialogButtonBox *bbox = new QDialogButtonBox();
   bbox->addButton(QDialogButtonBox::Ok);
@@ -472,6 +476,13 @@ SettingsDialog::SettingsDialog(QWidget *parent)
   QObject::connect(bbox, SIGNAL(accepted()), this, SLOT(accept()));
   QObject::connect(bbox, SIGNAL(rejected()), this, SLOT(reject()));
   QObject::connect(bbox, SIGNAL(helpRequested()), this, SLOT(showHelp()));
+}
+
+void
+SettingsDialog::tabSelected() {
+    if(_tabs->currentIndex()==3) {
+        _devices->populateDeviceSettingsView();
+    }
 }
 
 void
@@ -1217,32 +1228,35 @@ EffectSettingsView::onQRMToggled(bool enabled) {
 DeviceSettingsView::DeviceSettingsView(QWidget *parent)
   : QWidget(parent)
 {
-  Settings settings;
+    //Settings settings;
+    _settings = new Settings();
 
   _outputDevices = new QComboBox();
   _outputDevices->setToolTip(tr("Select the audio output device."));
-  QAudioDeviceInfo currentDevice = settings.outputDevice();
-  QList<QAudioDeviceInfo> devices = QAudioDeviceInfo::availableDevices(QAudio::AudioOutput);
-  foreach (auto device, devices) {
-    _outputDevices->addItem(device.deviceName());
-    if (device == currentDevice)
-      _outputDevices->setCurrentIndex(_outputDevices->model()->rowCount()-1);
-  }
+//  QAudioDeviceInfo currentDevice = settings.outputDevice();
+//  QList<QAudioDeviceInfo> devices = QAudioDeviceInfo::availableDevices(QAudio::AudioOutput);
+//  foreach (auto device, devices) {
+//    _outputDevices->addItem(device.deviceName());
+//    if (device == currentDevice)
+//      _outputDevices->setCurrentIndex(_outputDevices->model()->rowCount()-1);
+//  }
 
   _inputDevices = new QComboBox();
   _inputDevices->setToolTip(tr("Select the audio input device used for decoding CW send by you."));
-  currentDevice = settings.inputDevice();
-  devices = QAudioDeviceInfo::availableDevices(QAudio::AudioInput);
-  foreach (auto device, devices) {
-    _inputDevices->addItem(device.deviceName());
-    if (device == currentDevice)
-      _inputDevices->setCurrentIndex(_inputDevices->model()->rowCount()-1);
-  }
+//  currentDevice = settings.inputDevice();
+//  devices = QAudioDeviceInfo::availableDevices(QAudio::AudioInput);
+//  foreach (auto device, devices) {
+//    _inputDevices->addItem(device.deviceName());
+//    if (device == currentDevice)
+//      _inputDevices->setCurrentIndex(_inputDevices->model()->rowCount()-1);
+//  }
 
   _decoderLevel = new QSpinBox();
   _decoderLevel->setMinimum(-60);
   _decoderLevel->setMaximum(0);
-  _decoderLevel->setValue(int(settings.decoderLevel()));
+//  _decoderLevel->setValue(int(settings.decoderLevel()));
+  _decoderLevel->setValue(int(_settings->decoderLevel()));
+
   _decoderLevel->setToolTip(tr("Specifies the detector threshold in dB for decoding CW."));
 
   QFormLayout *layout = new QFormLayout();
@@ -1259,4 +1273,24 @@ DeviceSettingsView::save() {
   settings.setOutputDevice(_outputDevices->currentText());
   settings.setInputDevice(_inputDevices->currentText());
   settings.setDecoderLevel(_decoderLevel->value());
+}
+
+void DeviceSettingsView::populateDeviceSettingsView() {
+
+  QAudioDeviceInfo currentDevice = _settings->outputDevice();
+  QList<QAudioDeviceInfo> devices = QAudioDeviceInfo::availableDevices(QAudio::AudioOutput);
+  foreach (auto device, devices) {
+    _outputDevices->addItem(device.deviceName());
+    if (device == currentDevice)
+      _outputDevices->setCurrentIndex(_outputDevices->model()->rowCount()-1);
+  }
+
+  currentDevice = _settings->inputDevice();
+  devices = QAudioDeviceInfo::availableDevices(QAudio::AudioInput);
+  foreach (auto device, devices) {
+    _inputDevices->addItem(device.deviceName());
+    if (device == currentDevice)
+      _inputDevices->setCurrentIndex(_inputDevices->model()->rowCount()-1);
+  }
+
 }

--- a/src/settings.cc
+++ b/src/settings.cc
@@ -451,8 +451,6 @@ SettingsDialog::SettingsDialog(QWidget *parent)
   _tutor = new TutorSettingsView();
   _code  = new CodeSettingsView();
   _effects = new EffectSettingsView();
-
-  /* TODO: split DeviceSettingsView into a dummy and delay the population of it */
   _devices = new DeviceSettingsView();
 
   _tabs = new QTabWidget();

--- a/src/settings.hh
+++ b/src/settings.hh
@@ -359,7 +359,6 @@ class DeviceSettingsView: public QWidget
 
 public:
   explicit DeviceSettingsView(QWidget *parent=0);
-
   void populateDeviceSettingsView();
   void save();
 
@@ -379,10 +378,10 @@ public:
 
 public slots:
   virtual void accept();
-  void tabSelected();
 
 protected slots:
   void showHelp();
+  void tabSelected();
 
 protected:
   QTabWidget *_tabs;

--- a/src/settings.hh
+++ b/src/settings.hh
@@ -360,12 +360,14 @@ class DeviceSettingsView: public QWidget
 public:
   explicit DeviceSettingsView(QWidget *parent=0);
 
+  void populateDeviceSettingsView();
   void save();
 
 protected:
   QComboBox *_inputDevices;
   QComboBox *_outputDevices;
   QSpinBox  *_decoderLevel;
+  Settings *_settings;
 };
 
 /** The preferences dialog. */
@@ -377,6 +379,7 @@ public:
 
 public slots:
   virtual void accept();
+  void tabSelected();
 
 protected slots:
   void showHelp();

--- a/src/settings.hh
+++ b/src/settings.hh
@@ -96,7 +96,9 @@ public:
   bool kochPrefLastChars() const;
   /** Koch totor: Sets if "new" chars are more likely to be picked by the tutor. */
   void setKochPrefLastChars(bool pref);
-
+  /** Koch tutor: Sets the increase in the likelihood of last chars*/
+  void setKochLastCharFrequencyFactor(int lastCharFrequencyFactor);
+  int  KochLastCharFrequencyFactor() const;
   bool kochRepeatLastChar() const;
   void setKochRepeatLastChar(bool enable);
 
@@ -216,10 +218,12 @@ protected slots:
   void onMaxSet(int value);
   void onInfiniteToggled(bool enabled);
   void onShowSummaryToggled(bool enabled);
+  void onPreferLastCharToggled(bool enabled);
 
 protected:
   QSpinBox *_lesson;
   QCheckBox *_prefLastChars;
+  QSpinBox *_lastCharFrequencyFactor;
   QCheckBox *_repLastChar;
   QSpinBox *_minGroupSize;
   QSpinBox *_maxGroupSize;

--- a/src/settings.hh
+++ b/src/settings.hh
@@ -381,7 +381,6 @@ public slots:
 
 protected slots:
   void showHelp();
-  void tabSelected();
 
 protected:
   QTabWidget *_tabs;

--- a/src/tutor.cc
+++ b/src/tutor.cc
@@ -55,10 +55,11 @@ inline QVector<QChar> _initKochLessons() {
 QVector<QChar> KochTutor::_lessons = _initKochLessons();
 
 
-KochTutor::KochTutor(MorseEncoder *encoder, int lesson, bool prefLastChars, bool repeatLastChar,
+KochTutor::KochTutor(MorseEncoder *encoder, int lesson, bool prefLastChars,  int lastCharFrequencyFactor,
+bool repeatLastChar,
                      size_t minGroupSize, size_t maxGroupSize,
                      int lines, bool showSummary, int successThreshold, QObject *parent)
-  : Tutor(encoder, parent), _lesson(lesson), _prefLastChars(prefLastChars),
+  : Tutor(encoder, parent), _lesson(lesson), _prefLastChars(prefLastChars), _lastCharFrequencyFactor(lastCharFrequencyFactor),
     _repeatLastChar(repeatLastChar), _minGroupSize(std::min(minGroupSize, maxGroupSize)),
     _maxGroupSize(std::max(minGroupSize, maxGroupSize)), _lines(lines), _linecount(0),
     _showSummary(showSummary), _threshold(successThreshold), _text(),
@@ -113,6 +114,16 @@ KochTutor::prefLastChars() const {
 void
 KochTutor::setPrefLastChars(bool pref) {
   _prefLastChars = pref;
+}
+
+int
+KochTutor::lastCharFrequencyFactor() const {
+  return _lastCharFrequencyFactor;
+}
+
+void
+KochTutor::setLastCharFrequencyFactor(int lastCharFrequencyFactor) {
+  _lastCharFrequencyFactor = lastCharFrequencyFactor;
 }
 
 bool
@@ -227,7 +238,7 @@ KochTutor::_nextline() {
       if (_prefLastChars) {
         double v = -1;
         while ((v < 0) || (v >= _lesson)) {
-          v = (_lesson + _lesson*std::log(double(rand())/RAND_MAX)/4);
+             v = (_lesson + _lesson*std::log(double(rand())/RAND_MAX)/_lastCharFrequencyFactor);
         }
         idx = size_t(v);
       } else {

--- a/src/tutor.hh
+++ b/src/tutor.hh
@@ -60,7 +60,7 @@ public:
    * @param prefLastChars If @c true, specifies the if the symbols of the more recent lessons
    *        should be samples more likely by the tutor.
    * @param parent Specifies the QObject parent. */
-  KochTutor(MorseEncoder *encoder, int lesson=2, bool prefLastChars=false, bool repeatLastChar=false,
+  KochTutor(MorseEncoder *encoder, int lesson=2, bool prefLastChars=false, int lastCharFrequencyFactor=1, bool repeatLastChar=false,
             size_t minGroupSize=5, size_t maxGroupSize=5,
             int lines=5, bool showSummary=false, int successThreshold=90, QObject *parent=nullptr);
   /** Destructor. */
@@ -78,6 +78,10 @@ public:
   bool prefLastChars() const;
   /** Enable preferred sampling of recent symbols. */
   void setPrefLastChars(bool pref);
+  /** Return LastCharFrequencyFactor */
+  int lastCharFrequencyFactor() const;
+  void setLastCharFrequencyFactor(int lastCharFrequencyFactor);
+
   /** Repetition of last added char at the beginning of a session. */
   bool repeatLastChar() const;
   /** Enable repetition of last added char at the beginning of a session. */
@@ -111,6 +115,8 @@ protected:
   int _lesson;
   /** The "prefer last chars" flag. */
   bool _prefLastChars;
+  /** The extent to which "last chars" should be preferred*/
+  int _lastCharFrequencyFactor;
   /** The "repeat last char" flag. */
   bool _repeatLastChar;
   /** The minimum group size. */


### PR DESCRIPTION
Searching for audio devices in DeviceSettingsView::DeviceSettingsView may take a long time and is not typically required for the majority of cases for which one would call the Settings dialog.

Therefore, the work of the constructor is split by adding a new function `DeviceSettingsView::populateDeviceSettingsView` which populates the widgets set up by the constructor only if the `Devices` tab is clicked.